### PR TITLE
Allow customizing the search engines via package settings

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -22,5 +22,13 @@
     {
         "caption": "Search Anywhere: From Input (ask Search Engine)",
         "command": "search_anywhere_from_input_ask"
+    },
+    {
+        "caption": "Search Anywhere: Settings",
+        "command": "edit_settings",
+        "args": {
+            "base_file": "${packages}/Search Anywhere/searchanywhere.sublime-settings",
+            "default": "{\n\t$0\n}\n"
+        }
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -51,5 +51,35 @@
                 ]
             }
         ]
+    },
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Search Anywhere",
+                        "children":
+                        [
+                            {
+                                "command": "edit_settings",
+                                "args": {
+                                    "base_file": "${packages}/Search Anywhere/searchanywhere.sublime-settings",
+                                    "default": "{\n\t$0\n}\n"
+                                },
+                                "caption": "Settings"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ The preferred method is to use the [Sublime Package Manager](http://wbond.net/su
 
     $ https://github.com/ericmartel/Sublime-Text-2-Search-Anywhere-Plugin
 
+## Customizing the search engines
+
+The list of search engines is defined by the `searchanywhere_searchengines` setting. To customize it, override the setting in your user settings.
+
+Create or edit `Packages/User/searchanywhere.sublime-settings` (use `Preferences > Browse Packages…` to find the directory) and add your own list:
+
+    {
+        "searchanywhere_searchengines": [
+            {
+                "name": "DuckDuckGo",
+                "baseurl": "duckduckgo.com",
+                "searchurl": "https://duckduckgo.com/?q={0}"
+            }
+        ]
+    }
+
+Each entry has a `name` (shown in the quick panel), a `baseurl` (shown next to the name) and a `searchurl` where `{0}` is replaced by the search text.
+
 ## Complete Documentation
 
 A website is currently under construction to explain the usage of the plugin in details. In the meantime, please visit this [Web Site](http://www.ericmartel.com/sublime-text-2-search-anywhere/).

--- a/searchanywhere.py
+++ b/searchanywhere.py
@@ -41,27 +41,37 @@ def SearchFor(view, text, searchurl):
     url = searchurl.replace('{0}', text.replace(' ','%20'))
     webbrowser.open_new_tab(url)
 
-def ShowSearchEnginesList(window, callback):
-    searchengines = []
-    if os.path.exists(searchanywhere_dir + os.sep + 'searchengines.json'):
-        f = open(searchanywhere_dir + os.sep + 'searchengines.json')
+# Returns the list of search engines. When the 'searchanywhere_searchengines'
+# setting is defined (e.g. in the user's SearchAnywhere.sublime-settings), it
+# takes precedence over the bundled searchengines.json, so users can customize
+# the list without editing package files that get overwritten on update.
+def GetSearchEngines():
+    settings = sublime.load_settings(__name__ + '.sublime-settings')
+    searchengines = settings.get('searchanywhere_searchengines')
+    if searchengines:
+        return searchengines
+
+    filename = searchanywhere_dir + os.sep + 'searchengines.json'
+    if os.path.exists(filename):
+        f = open(filename)
         searchengineslist = json.load(f)
         f.close()
+        return searchengineslist.get('searchengines')
 
-        for entry in searchengineslist.get('searchengines'):
-            formattedentry = []
-            formattedentry.append(entry.get('name'))
-            formattedentry.append(entry.get('baseurl'))
-            searchengines.append(formattedentry)
+    return []
+
+def ShowSearchEnginesList(window, callback):
+    searchengines = []
+    for entry in GetSearchEngines():
+        formattedentry = []
+        formattedentry.append(entry.get('name'))
+        formattedentry.append(entry.get('baseurl'))
+        searchengines.append(formattedentry)
 
     window.show_quick_panel(searchengines, callback)
 
 def GetSearchEngineEntry(picked):
-    f = open(searchanywhere_dir + os.sep + 'searchengines.json')
-    searchengineslist = json.load(f)
-    entry = searchengineslist.get('searchengines')[picked]
-    f.close()
-    return entry
+    return GetSearchEngines()[picked]
 
 class SearchAnywhereFromSelectionAskCommand(sublime_plugin.TextCommand):
     def run(self, edit):

--- a/searchanywhere.sublime-settings
+++ b/searchanywhere.sublime-settings
@@ -1,6 +1,12 @@
 {
-    "schema_version": "1.2",
-    "searchengines": [
+    // The list of search engines offered by Search Anywhere.
+    // To customize it, open Preferences > Package Settings > Search Anywhere >
+    // Settings - User and add your own "searchanywhere_searchengines" list.
+    // Settings placed there override the ones below and survive package updates.
+    //   name:      label shown in the quick panel
+    //   baseurl:   description shown next to the name
+    //   searchurl: target url, where {0} is replaced by the search text
+    "searchanywhere_searchengines": [
         {
             "name": "Google",
             "baseurl": "www.google.com",
@@ -62,4 +68,19 @@
             "searchurl": "http://www.ruby-doc.org/search.html?cx=011815814100681837392%3Awnccv6st5qk&q={0}&sa=Search&cof=FORID%3A9"
         }
     ]
+
+    // The default search engine, set by "Set Default Search Engine" and used by
+    // the "From Selection" / "From Input" commands. Both keys are stored together.
+    // "searchanywhere_searchengine": "Google",
+    // "searchanywhere_searchurl": "http://www.google.com/search?q={0}",
+
+    // Per-extension default engines, set by "Set Search Engine For File Type".
+    // When searching, a matching extension takes precedence over the default above.
+    // "searchanywhere_type_searchengine": [
+    //     {
+    //         "extension": ".rb",
+    //         "name": "Ruby Doc",
+    //         "searchurl": "http://www.ruby-doc.org/search.html?q={0}"
+    //     }
+    // ]
 }


### PR DESCRIPTION
Fixes #4.

Previously the search engine list could only be changed by editing the bundled `searchengines.json`, which gets overwritten on every package update (and copying it to `Packages/User` had no effect, as the reporter noted).

This adds a `searchanywhere_searchengines` setting. Users override it in `Packages/User/searchanywhere.sublime-settings`, which survives updates — no need to hand-create or edit package files.

- Read engines from the `searchanywhere_searchengines` setting, falling back to the bundled `searchengines.json` for backward compatibility.
- Ship a default `searchanywhere.sublime-settings` so the setting is discoverable and its format documented.
- Document the customization in the README.