### PR TITLE
Fix broken homepage link (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The preferred method is to use the [Sublime Package Manager](http://wbond.net/su
 
 ## Complete Documentation
 
-A website is currently under construction to explain the usage of the plugin in details. In the meantime, please visit this [Web Site](http://www.ericmartel.com/sublime-text-2-search-anywhere/).
+For usage instructions, please visit the [project page on GitHub](https://github.com/ericmartel/Sublime-Text-2-Search-Anywhere-Plugin).
 
 # License
 

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,6 +1,6 @@
 Search Anywhere by Eric Martel (emartel@gmail.com / www.ericmartel.com)
 
-Thank you for installing Search Anywhere. For detailed instructions please visit http://www.ericmartel.com/sublime-text-2-search-anywhere/. All commands are available through menus, context menus and the command palette.
+Thank you for installing Search Anywhere. For detailed instructions please visit https://github.com/ericmartel/Sublime-Text-2-Search-Anywhere-Plugin. All commands are available through menus, context menus and the command palette.
 
 Please direct any feedback to emartel@gmail.com or through github at https://github.com/ericmartel/Sublime-Text-2-Search-Anywhere-Plugin.
 


### PR DESCRIPTION
The documentation link `http://www.ericmartel.com/sublime-text-2-search-anywhere/` returns a **404** (verified).

This updates the link in both `README.md` and `messages/install.txt` to point at the GitHub project page, which is live.